### PR TITLE
Fix unsupported gradle setup

### DIFF
--- a/apps/hops-api/build.gradle.kts
+++ b/apps/hops-api/build.gradle.kts
@@ -10,7 +10,7 @@ val prometeus_version = "1.6.5"
 
 plugins {
     application
-    kotlin("jvm") version "1.4.21"
+    kotlin("jvm")
     id("com.github.johnrengelman.shadow") version "5.0.0"
 }
 

--- a/apps/hops-api/src/main/kotlin/no/nav/helse/hops/auth/Auth.kt
+++ b/apps/hops-api/src/main/kotlin/no/nav/helse/hops/auth/Auth.kt
@@ -3,7 +3,7 @@ package no.nav.helse.hops.auth
 import io.ktor.application.Application
 import io.ktor.application.install
 import io.ktor.auth.Authentication
-import io.ktor.util.*
+import io.ktor.util.KtorExperimentalAPI
 import no.nav.security.token.support.ktor.RequiredClaims
 import no.nav.security.token.support.ktor.tokenValidationSupport
 

--- a/apps/hops-api/src/main/kotlin/no/nav/helse/hops/auth/Auth.kt
+++ b/apps/hops-api/src/main/kotlin/no/nav/helse/hops/auth/Auth.kt
@@ -3,9 +3,11 @@ package no.nav.helse.hops.auth
 import io.ktor.application.Application
 import io.ktor.application.install
 import io.ktor.auth.Authentication
+import io.ktor.util.*
 import no.nav.security.token.support.ktor.RequiredClaims
 import no.nav.security.token.support.ktor.tokenValidationSupport
 
+@KtorExperimentalAPI
 fun Application.configureAuthentication() {
     val config = this.environment.config
     val issuer = config

--- a/apps/hops-bestilling/build.gradle.kts
+++ b/apps/hops-bestilling/build.gradle.kts
@@ -16,7 +16,7 @@ object Version {
 plugins {
     java
     application
-    kotlin("jvm") version "1.4.21"
+    kotlin("jvm")
     id("com.github.johnrengelman.shadow") version "6.1.0"
     id("org.jlleitschuh.gradle.ktlint") version "10.0.0"
 }

--- a/apps/hops-oppslag/build.gradle.kts
+++ b/apps/hops-oppslag/build.gradle.kts
@@ -15,7 +15,7 @@ object Version {
 plugins {
     java
     application
-    kotlin("jvm") version "1.4.21"
+    kotlin("jvm")
     id("com.github.johnrengelman.shadow") version "6.1.0"
     id("org.jlleitschuh.gradle.ktlint") version "10.0.0"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    kotlin("jvm") version "1.4.21" apply false
+}


### PR DESCRIPTION
Fixes:

The Kotlin Gradle plugin was loaded multiple times in different subprojects, which is not supported and may break the build.
This might happen in subprojects that apply the Kotlin plugins with the Gradle 'plugins { ...  }' 
DSL if they specify explicit versions, even if the versions are equal.
Please add the Kotlin plugin to the common parent project or the root project, then remove the versions in the subprojects.
If the parent project does not need the plugin, add 'apply false' to the
plugin line.
See: https://docs.gradle.org/current/userguide/plugins.html#sec:subprojects_plugins_dsl