### PR TITLE
merge remove-ktlintFormat-build-dependency into main

### DIFF
--- a/apps/hops-api/build.gradle.kts
+++ b/apps/hops-api/build.gradle.kts
@@ -14,7 +14,6 @@ application {
 tasks {
     withType<KotlinCompile> {
         kotlinOptions.jvmTarget = "11"
-        dependsOn("ktlintFormat")
     }
     test {
         useJUnitPlatform()

--- a/apps/hops-bestilling/build.gradle.kts
+++ b/apps/hops-bestilling/build.gradle.kts
@@ -14,7 +14,6 @@ application {
 tasks {
     withType<KotlinCompile> {
         kotlinOptions.jvmTarget = "11"
-        dependsOn("ktlintFormat")
     }
     test {
         useJUnitPlatform()

--- a/apps/hops-hendelser/build.gradle.kts
+++ b/apps/hops-hendelser/build.gradle.kts
@@ -14,7 +14,6 @@ application {
 tasks {
     withType<KotlinCompile> {
         kotlinOptions.jvmTarget = "11"
-        dependsOn("ktlintFormat")
     }
     test {
         useJUnitPlatform()

--- a/apps/hops-oppslag/build.gradle.kts
+++ b/apps/hops-oppslag/build.gradle.kts
@@ -14,7 +14,6 @@ application {
 tasks {
     withType<KotlinCompile> {
         kotlinOptions.jvmTarget = "11"
-        dependsOn("ktlintFormat")
     }
     test {
         useJUnitPlatform()

--- a/libs/hops-common-core/build.gradle.kts
+++ b/libs/hops-common-core/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
 tasks {
     withType<KotlinCompile> {
         kotlinOptions.jvmTarget = "11"
-        dependsOn("ktlintFormat")
     }
     test {
         useJUnitPlatform()

--- a/libs/hops-common-fhir/build.gradle.kts
+++ b/libs/hops-common-fhir/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
 tasks {
     withType<KotlinCompile> {
         kotlinOptions.jvmTarget = "11"
-        dependsOn("ktlintFormat")
     }
     test {
         useJUnitPlatform()

--- a/libs/hops-common-ktor/build.gradle.kts
+++ b/libs/hops-common-ktor/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
 tasks {
     withType<KotlinCompile> {
         kotlinOptions.jvmTarget = "11"
-        dependsOn("ktlintFormat")
     }
     test {
         useJUnitPlatform()


### PR DESCRIPTION
* removed dependsOn("ktlintFormat") from KotlinCompile

Running ktlint-check with every build has been considered too strict by the team and should instead be executed as part of a check on every PR. This does not address the root of the problem in issue  #94 , but removes the warning message.