### PR TITLE
merge test-container-explicit-hapi-version into main

### DIFF
--- a/apps/hops-hendelser/src/test/kotlin/no/nav/helse/hops/testUtils/TestContainerFactory.kt
+++ b/apps/hops-hendelser/src/test/kotlin/no/nav/helse/hops/testUtils/TestContainerFactory.kt
@@ -5,10 +5,10 @@ import org.testcontainers.containers.wait.strategy.Wait
 
 object TestContainerFactory {
     fun hapiFhirServer() = GenericContainer<Nothing>(
-        "hapiproject/hapi"
+        "hapiproject/hapi:v5.3.0"
     ).apply {
         withExposedPorts(8080)
-        waitingFor(Wait.forHttp("/fhir/Task"))
+        waitingFor(Wait.forHttp("/fhir/metadata"))
     }
 
     fun mockOauth2Server() = GenericContainer<Nothing>(


### PR DESCRIPTION
* Explicitly specify hapiproject/hapi image version instead of using latest.
* Wait for the /metadata instead of /task.