### PR TITLE
Update naiserator.yaml

### DIFF
--- a/apps/hops-api/.nais/naiserator.yaml
+++ b/apps/hops-api/.nais/naiserator.yaml
@@ -12,7 +12,8 @@ spec:
   maskinporten:
     enabled: true
     scopes:
-      - name: "nav:helse/v1/helseopplysninger"
+      consumes:
+       - name: "nav:helse/v1/helseopplysninger"
   liveness:
     path: /isAlive
     initialDelay: 10


### PR DESCRIPTION
Hello. Har oppdatert digdirator med å ha støtte for å lage scopes, scopes/APIs som brukes av NAIS apper for maskinporten sikring av apier. Da har de blitt en liten endringen i spec hvor du enten kan consume scopes eller expose. Doc til nais vill bli oppdatert og vill da finne mer info om endringene.