### PR TITLE
Only use github

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -29,7 +29,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           args: --sarif-file-output=snyk.sarif --all-sub-projects --configuration-matching='^runtimeClasspath'
-          command: test monitor # Use both test (for GitHub security issues) and monitor (for snyk.com monitoring)
+          command: test
 
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v1


### PR DESCRIPTION
Both, monitor and test at the same time works with the CLI but not with this github action.
Uses github security issues for now.