### PR TITLE
POC gradle cache in docker layer

### DIFF
--- a/.docker/builder/Dockerfile
+++ b/.docker/builder/Dockerfile
@@ -1,0 +1,10 @@
+# This Dockerfile is used to create a docker-image containing the Gradle cache including Maven packages.
+# Build local (windows), navigate to project root and run:
+# docker build -f E:\repos\helseopplysninger\.docker\build\Dockerfile -t hops-build:latest .
+FROM gradle:7.2.0-jdk16 AS build
+COPY . .
+RUN find . ! -name "*.kts" ! -name "gradle.properties" -delete; echo 0
+
+FROM gradle:7.2.0-jdk16
+COPY --from=build /home/gradle .
+RUN gradle assemble --no-daemon && rm -rf *

--- a/.docker/builder/Dockerfile
+++ b/.docker/builder/Dockerfile
@@ -1,6 +1,4 @@
 # This Dockerfile is used to create a docker-image containing the Gradle cache including Maven packages.
-# Build local (windows), navigate to project root and run:
-# docker build -f E:\repos\helseopplysninger\.docker\build\Dockerfile -t hops-build:latest .
 FROM gradle:7.2.0-jdk16 AS build
 COPY . .
 RUN find . ! -name "*.kts" ! -name "gradle.properties" -delete; echo 0

--- a/.github/workflows/docker-build-image.yaml
+++ b/.github/workflows/docker-build-image.yaml
@@ -9,7 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-      - uses: docker/setup-buildx-action@v1.5.1
 
       - uses: docker/login-action@v1
         with:

--- a/.github/workflows/docker-build-image.yaml
+++ b/.github/workflows/docker-build-image.yaml
@@ -1,0 +1,24 @@
+# Creates and publishes a Docker image containing a Gradle cache with all the required Maven dependencies.
+on:
+  schedule:
+    - cron: '0 0 * * SUN'
+  workflow_dispatch:
+
+jobs:
+  build-docker-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: docker/setup-buildx-action@v1.5.1
+
+      - uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v2.7.0
+        with:
+          file: .docker/builder/Dockerfile
+          push: true
+          tags: ghcr.io/navikt/hops-build:latest

--- a/.github/workflows/docker-build-image.yaml
+++ b/.github/workflows/docker-build-image.yaml
@@ -20,4 +20,4 @@ jobs:
         with:
           file: .docker/builder/Dockerfile
           push: true
-          tags: ghcr.io/navikt/hops-build:latest
+          tags: ghcr.io/navikt/hops-build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/navikt/hops-build AS build
 COPY . .
 ARG project
-RUN gradle apps:${project}:shadowJar --no-daemon
+RUN gradle apps:${project}:shadowJar --no-daemon --no-build-cache
 
 FROM navikt/java:16
 COPY --from=build /home/gradle/apps/*/build/libs/*.jar app.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,23 @@
-FROM gradle:7.2.0-jdk16 AS build
-WORKDIR /home/gradle/src
-COPY --chown=gradle:gradle . .
-ARG project
-ARG task=shadowJar
-RUN gradle apps:${project}:${task} --no-daemon
+# Used to create a source-tree containing only Gradle files.
+# Needed because 'docker copy' does not support combining recursive copy and pattern matching.
+FROM gradle:7.2.0-jdk16 AS gradle-files
+COPY . .
+RUN find . ! -name "*.kts" ! -name "gradle.properties" -delete; echo 0
 
-FROM navikt/java:16
+# Pulls all maven dependencies.
+# Is only rebuilt if a file from the 'gradle-files' stage is modified.
+FROM gradle:7.2.0-jdk16 AS cache
+COPY --from=gradle-files /home/gradle .
+RUN gradle assemble --no-daemon
+
+# Uses the maven packages from the 'cache' stage and builds the specified project.
+FROM gradle:7.2.0-jdk16 AS build
+COPY --from=cache /root/.gradle /root/.gradle
+COPY . .
 ARG project
-COPY --from=build /home/gradle/src/apps/${project}/build/libs/*.jar app.jar
+RUN gradle apps:${project}:shadowJar --no-daemon
+
+# Hardened navikt production image.
+# Contains only the fat JAR from the 'build' stage, no other build artifact.
+FROM navikt/java:16
+COPY --from=build /home/gradle/apps/*/build/libs/*.jar app.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/navikt/hops-build:latest AS build
+FROM ghcr.io/navikt/hops-build AS build
 COPY . .
 ARG project
 RUN gradle apps:${project}:shadowJar --no-daemon

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,4 @@
-FROM gradle:7.2.0-jdk16 AS gradle-files
-COPY . .
-RUN find . ! -name "*.kts" ! -name "gradle.properties" -delete; echo 0
-
-FROM gradle:7.2.0-jdk16 AS build
-COPY --from=gradle-files /home/gradle .
-RUN gradle assemble --no-daemon
+FROM ghcr.io/navikt/hops-build:latest AS build
 COPY . .
 ARG project
 RUN gradle apps:${project}:shadowJar --no-daemon

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,13 @@
-# Used to create a source-tree containing only Gradle files.
-# Needed because 'docker copy' does not support combining recursive copy and pattern matching.
 FROM gradle:7.2.0-jdk16 AS gradle-files
 COPY . .
 RUN find . ! -name "*.kts" ! -name "gradle.properties" -delete; echo 0
 
-# Pulls all maven dependencies.
-# Is only rebuilt if a file from the 'gradle-files' stage is modified.
-FROM gradle:7.2.0-jdk16 AS cache
+FROM gradle:7.2.0-jdk16 AS build
 COPY --from=gradle-files /home/gradle .
 RUN gradle assemble --no-daemon
-
-# Uses the maven packages from the 'cache' stage and builds the specified project.
-FROM gradle:7.2.0-jdk16 AS build
-COPY --from=cache /root/.gradle /root/.gradle
 COPY . .
 ARG project
 RUN gradle apps:${project}:shadowJar --no-daemon
 
-# Hardened navikt production image.
-# Contains only the fat JAR from the 'build' stage, no other build artifact.
 FROM navikt/java:16
 COPY --from=build /home/gradle/apps/*/build/libs/*.jar app.jar


### PR DESCRIPTION
Fungerer bra lokalt, alle appene gjennbruker samme docker layer med alle maven pakker (+ annet gradle cache). Dersom gradle filer har endringer må hele cache layered bygges pånytt, dette tar ca 3min. 

Gjennstår å teste og vurdere om dette fungerer bra i pipelinen.

Lokale test resultater med ny og gammel Dockerfile: 
- Docker-compose innebærer bygging av alle appene.
- Single app vil si kun hops-eventstore.
- Tid er i sekunder. 
- 1 forsøk per måling.

| | Old | New |
| - | - | - |
| Clean docker-compose build | 259 | 270 |
| Clean build of single app | 186 | 241 |
| Rebuild single app | 144 | 41 |

Utifra målingene ser vi at det er en del tregere å gjøre et clean bygg der pakkene må hentes pånytt, dette er fordi gradle kjøres 2 ganger. Hvis gradle cache kan brukes er det en del raskere, men er dette verdt det?

UPDATE:
Oppdaterte slik at det er en egen github-workflow som periodisk (hver søndag) lager et nytt base-image bestående av gradle cache. På denne måten vil ikke alle dependencies måtte hentes grunnet endring i gradle fil, bare dependenciesene som har endret seg trenger å hentes.