### PR TITLE
ci: set empty maskinporten scope consumers

### DIFF
--- a/apps/hops-fileshare/.nais/naiserator.yaml
+++ b/apps/hops-fileshare/.nais/naiserator.yaml
@@ -48,8 +48,7 @@ spec:
           allowedIntegrations:
             - maskinporten
           atMaxAge: 120
-          consumers:
-            - orgno: "123456789"
+          consumers: []
   gcp:
     buckets:
       - name: helse-hops-fileshare


### PR DESCRIPTION
Invalid Norwegian organization numbers currently result in infrastructure errors during deployment (which will be fixed, but our alarms get quite noisy at the moment).